### PR TITLE
Support externalized messages

### DIFF
--- a/lib/rocketamf/values/externalized.rb
+++ b/lib/rocketamf/values/externalized.rb
@@ -6,8 +6,20 @@ module RocketAMF
         %w[ clientIdBytes messageIdBytes ]
       ]
 
-      def to_uuid(obj)
-        "%08X-%04X-%04X-%04X-%08X%04X" % obj.to_s.unpack("NnnnNn")
+      def to_pretty_uuid(obj)
+        if obj.is_a?(StringIO)
+          "%08X-%04X-%04X-%04X-%08X%04X" % obj.string.unpack("NnnnNn")
+        else
+          nil
+        end
+      end
+
+      def to_binary_uuid(obj)
+        if obj.is_a?(String) && obj.size == 36
+          obj.gsub('-','').scan(/../).map {|pair| pair.hex}.pack('C*')
+        else
+          nil
+        end
       end
 
       def populate(source, fields)
@@ -33,13 +45,23 @@ module RocketAMF
         populate(source, ExternalizedFields)
       end
 
+      def clientId=(obj)
+        @clientIdBytes = to_binary_uuid(obj)
+        @clientId = obj
+      end
+
       def clientIdBytes=(obj)
-        @clientId = to_uuid(obj)
+        @clientId = to_pretty_uuid(obj)
         @clientIdBytes = obj
       end
 
+      def messageId=(obj)
+        @messageIdBytes = to_binary_uuid(obj)
+        @messageId = obj
+      end
+
       def messageIdBytes=(obj)
-        @messageId = to_uuid(obj)
+        @messageId = to_pretty_uuid(obj)
         @messageIdBytes = obj
       end
     end
@@ -54,8 +76,13 @@ module RocketAMF
         populate(source, ExternalizedFields)
       end
 
+      def correlationId=(obj)
+        @correlationIdBytes = to_binary_uuid(obj)
+        @correlationId = obj
+      end
+
       def correlationIdBytes=(obj)
-        @correlationId = to_uuid(obj)
+        @correlationId = to_pretty_uuid(obj)
         @correlationIdBytes = obj
       end
     end

--- a/lib/rocketamf/values/externalized.rb
+++ b/lib/rocketamf/values/externalized.rb
@@ -1,0 +1,72 @@
+module RocketAMF
+  module Values
+    class AbstractMessage
+      ExternalizedFields = [
+        %w[ body clientId destination headers messageId timestamp timeToLive ],
+        %w[ clientIdBytes messageIdBytes ]
+      ]
+
+      def to_uuid(obj)
+        "%08X-%04X-%04X-%04X-%08X%04X" % obj.to_s.unpack("NnnnNn")
+      end
+
+      def populate(source, fields)
+        flags = []
+        loop do
+          flags << source.read(1).unpack('C').first
+          break if flags.last < 128
+        end
+
+        if fields && !fields.empty?
+          fields.each_with_index do |list, i|
+            list.each_with_index do |name, j|
+              if flags[i].ord[j] > 0
+                data = RocketAMF.deserialize(source, 3)
+                send("#{name}=", data)
+              end
+            end
+          end
+        end
+      end
+
+      def internalize(source)
+        populate(source, ExternalizedFields)
+      end
+
+      def clientIdBytes=(obj)
+        @clientId = to_uuid(obj)
+        @clientIdBytes = obj
+      end
+
+      def messageIdBytes=(obj)
+        @messageId = to_uuid(obj)
+        @messageIdBytes = obj
+      end
+    end
+
+    class AsyncMessage
+      ExternalizedFields = [
+        %w[ correlationId correlationIdBytes ],
+      ]
+
+      def internalize(source)
+        super
+        populate(source, ExternalizedFields)
+      end
+
+      def correlationIdBytes=(obj)
+        @correlationId = to_uuid(obj)
+        @correlationIdBytes = obj
+      end
+    end
+
+    class AcknowledgeMessage
+      ExternalizedFields = nil
+
+      def internalize(source)
+        super
+        populate(source, ExternalizedFields)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I am hitting a BlazeDS server that is wrapping a Java based server. I see a lot of the messages with types of "DSK", "DSA", "DSC", etc. These look like a shorthand message type, that uses bitmapped fields instead of string-based keys. After looking through the reference implementation and also the source code for Charles (the web proxy), I added support so that RocketAMF can deserialize these messages. For certain fields, such as messageIdBytes (which is a byte array), I have adjusted the setter methods to also set a human-readable version called (for example) messageId (which is just a string version of the UUID from the byte array). For completeness, a reverse method should be added so that if you set messageId, it'll create a 16-byte byte array and store the bytes directly.

By the way, one other random helper (not sure if this is necessary, but I added it) is this:
# convenience for instantiating TypedHash objects

Hash.class_eval { def +@; RocketAMF::Values::TypedHash.new("").update(self); end }

Let me know if any of this is helpful.

Thanks,

Steve Shreeve
