### PR TITLE
A few updates for your review

### DIFF
--- a/lib/rocketamf/class_mapping.rb
+++ b/lib/rocketamf/class_mapping.rb
@@ -17,12 +17,17 @@ module RocketAMF
       map :as => 'flex.messaging.messages.AbstractMessage', :ruby => 'RocketAMF::Values::AbstractMessage'
       map :as => 'flex.messaging.messages.RemotingMessage', :ruby => 'RocketAMF::Values::RemotingMessage'
       map :as => 'flex.messaging.messages.AsyncMessage', :ruby => 'RocketAMF::Values::AsyncMessage'
-      map :as => 'DSA', :ruby => 'RocketAMF::Values::AsyncMessageExt'
       map :as => 'flex.messaging.messages.CommandMessage', :ruby => 'RocketAMF::Values::CommandMessage'
-      map :as => 'DSC', :ruby => 'RocketAMF::Values::CommandMessageExt'
       map :as => 'flex.messaging.messages.AcknowledgeMessage', :ruby => 'RocketAMF::Values::AcknowledgeMessage'
-      map :as => 'DSK', :ruby => 'RocketAMF::Values::AcknowledgeMessageExt'
       map :as => 'flex.messaging.messages.ErrorMessage', :ruby => 'RocketAMF::Values::ErrorMessage'
+
+      map :as => 'flex.messaging.messages.HTTPMessage', :ruby => 'RocketAMF::Values::HTTPMessage'
+      map :as => 'flex.messaging.messages.SOAPMessage', :ruby => 'RocketAMF::Values::SOAPMessage'
+
+      map :as => 'DSA', :ruby => 'RocketAMF::Values::AsyncMessageExt'
+      map :as => 'DSC', :ruby => 'RocketAMF::Values::CommandMessageExt'
+      map :as => 'DSK', :ruby => 'RocketAMF::Values::AcknowledgeMessageExt'
+
       self
     end
 
@@ -229,8 +234,9 @@ module RocketAMF
       (ruby_obj.public_methods - @ignored_props).each do |method_name|
         # Add them to the prop hash if they take no arguments
         method_def = ruby_obj.method(method_name)
-        props[method_name.to_s] = ruby_obj.send(method_name) if method_def.arity == 0
-      end
+#        props[method_name.to_s] = ruby_obj.send(method_name) if method_def.arity == 0
+        props[method_name.to_s.chomp('_')] = ruby_obj.send(method_name) if method_def.arity == 0
+     end
       props
     end
   end

--- a/lib/rocketamf/values/messages.rb
+++ b/lib/rocketamf/values/messages.rb
@@ -67,6 +67,34 @@ module RocketAMF
       end
     end
 
+    # Maps to <tt>flex.messaging.messages.HTTPMessage</tt>
+    class HTTPMessage < AbstractMessage
+      attr_accessor :contentType
+      attr_accessor :method_
+      attr_accessor :url
+      attr_accessor :httpHeaders
+      attr_accessor :recordHeaders
+
+      def initialize
+        @destination = nil
+        @messageId = rand_uuid
+        @timestamp = Time.new.to_i*100
+        @timeToLive = 0
+        @headers = {}
+        @body = nil
+        @method_ = "GET"
+      end
+    end
+
+    # Maps to <tt>flex.messaging.messages.SOAPMessage</tt>
+    class SOAPMessage < HTTPMessage
+      def initialize
+        super
+        @contentType = "text/xml; charset=utf-8"
+        @method_ = "POST"
+      end
+    end
+
     # Maps to <tt>flex.messaging.messages.RemotingMessage</tt>
     class RemotingMessage < AbstractMessage
       # The name of the service to be called including package name


### PR DESCRIPTION
warhammerkid,

Thanks for your recent updates to RocketAMF. I made a few additional tweaks to enable my BlazeDS wrapper to work "out of the box" with your latest version. The commit message is:

```
* add HTTPMessage, SOAPMessage, and allow reserved attribute names with trailing underscore
```

The trailing underscore approach is probably lame, but there are some of the BlazeDS messages that use "method" as an attribute name. Since that conflicts with the existing usage of a method with the name "method", I just appended an underscore and then deal with it specifically (which is kind of ugly). Is there a cleaner way to handle this?

Thanks,

Steve
