### PR TITLE
Fix bug: read extra fields if flags array is shorter than fields

### DIFF
--- a/lib/rocketamf/values/messages.rb
+++ b/lib/rocketamf/values/messages.rb
@@ -50,6 +50,8 @@ module RocketAMF
 
         # Read fields and any remaining unmapped fields in a byte-set
         fields.each_with_index do |list, i|
+          break if flags[i].nil?
+
           list.each_with_index do |name, j|
             if flags[i] & 2**j != 0
               send("#{name}=", des.read_object)


### PR DESCRIPTION
if flags.length < fields.length, "flags[i] & 2**j != 0" will be evaluated as "nil & 2**j != 0", which is always true.
