### PR TITLE
Remove inline declaration to fix loading problem with dyld

### DIFF
--- a/ext/rocketamf_ext/serializer.c
+++ b/ext/rocketamf_ext/serializer.c
@@ -651,7 +651,7 @@ int ser_free_strtable_key(st_data_t key, st_data_t value, st_data_t ignored)
 
     return ST_DELETE;
 }
-inline void ser_free_cache(AMF_SERIALIZER *ser) {
+void ser_free_cache(AMF_SERIALIZER *ser) {
     if(ser->str_cache) {
         st_foreach(ser->str_cache, ser_free_strtable_key, 0);
         st_free_table(ser->str_cache);


### PR DESCRIPTION
The `inline` declaration of `ser_free_cache` could cause undefined symbol problem with dyld of OSX.

```
[2] pry(#<RubyAMF::RequestParser>)> env['rubyamf.response'].to_s
dyld: lazy symbol binding failed: Symbol not found: _ser_free_cache
  Referenced from: /.../rbenv/.../rocketamf-3f16cf/lib/rocketamf_ext.bundle
  Expected in: flat namespace

dyld: Symbol not found: _ser_free_cache
  Referenced from: /.../rbenv/.../rocketamf-3f16cf/lib/rocketamf_ext.bundle
  Expected in: flat namespace

[1]    3576 trace trap  bundle exec rails s
```
