### PR TITLE
Fix for proxied array barfing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,9 @@
 require 'rubygems'
 require 'rake'
-require 'rake/rdoctask'
-require 'rake/gempackagetask'
-require 'rspec/core/rake_task'
 require 'rake/extensiontask'
+require 'rdoc/task'
+require 'rubygems/package_task'
+require 'rspec/core/rake_task'
 
 desc 'Default: run the specs.'
 task :default => :spec
@@ -33,7 +33,7 @@ Rake::RDocTask.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include("lib") # Don't include ext folder because no one cares
 end
 
-Rake::GemPackageTask.new(spec) do |pkg|
+Gem::PackageTask.new(spec) do |pkg|
   pkg.need_zip = false
   pkg.need_tar = false
 end

--- a/ext/rocketamf_ext/serializer.c
+++ b/ext/rocketamf_ext/serializer.c
@@ -603,6 +603,16 @@ static VALUE ser3_serialize(VALUE self, VALUE obj) {
         klass = CLASS_OF(obj);
     }
 
+    //Detects proxy arrays and converts them to real arrays
+    if(type == T_OBJECT){
+      VALUE testObj = rb_check_array_type(obj);
+      if(testObj != Qnil){
+        obj = testObj;
+        type = T_ARRAY;
+        //TODO: clean up old object or will GC take care of it well enough?
+      }
+    }
+
     if(rb_respond_to(obj, id_encode_amf)) {
         rb_funcall(obj, id_encode_amf, 1, self);
     } else if(type == T_STRING || type == T_SYMBOL) {

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -52,6 +52,15 @@ describe "when serializing" do
       output.should == object_fixture('amf0-strict-array.bin')
     end
 
+    it "should serialize an array through a proxy class" do
+      expected = object_fixture("amf3-primitive-array.bin")
+      arr = ProxyArray.new
+      [1,2,3,4,5].each {|e| arr.push e}
+
+      output = RocketAMF.serialize(arr,3)
+      output.should == expected
+    end
+
     it "should serialize references" do
       obj = OtherClass.new
       obj.foo = "baz"
@@ -340,6 +349,15 @@ describe "when serializing" do
         input = [a, b, b]
 
         output = RocketAMF.serialize(input, 3)
+        output.should == expected
+      end
+
+      it "should serialize an array through a proxy class" do
+        expected = object_fixture("amf3-primitive-array.bin")
+        arr = ProxyArray.new
+        [1,2,3,4,5].each {|e| arr.push e}
+
+        output = RocketAMF.serialize(arr,3)
         output.should == expected
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,17 @@ class ClassMappingTest2 < ClassMappingTest
   attr_accessor :prop_c
 end
 module ANamespace; class TestRubyClass; end; end
+class ProxyArray
+  instance_methods.each {|m| undef_method m unless m=~ /^__|^send$|^object_id$/}
+  protected
+  def method_missing(name, *args, &block)
+    target.send(name, *args, &block)
+  end
+
+  def target
+    @target ||= []
+  end
+end
 class ExternalizableTest
   include RocketAMF::Pure::ReadIOHelpers
   include RocketAMF::Pure::WriteIOHelpers


### PR DESCRIPTION
- Added specs for serializing arrays which are transparently proxied through
  another class.
- Added check to native ext to convert an T_OBJECT to a T_ARRAY if
  possible, and leave it alone otherwise.
- Updated Rakefile to work with latest (10.0.4)

Let me know if you think this should be done differently. This solution is working for me. By the way thanks for your work getting AMF into C. My app is SO much faster with it.
